### PR TITLE
The URL_BASE constant was being overridden and so it was connecting via h

### DIFF
--- a/lib/OauthPhirehose.php
+++ b/lib/OauthPhirehose.php
@@ -2,7 +2,6 @@
 
 abstract class OauthPhirehose extends Phirehose
 {
-	const URL_BASE = 'http://stream.twitter.com/1/statuses/';
 
 	protected $auth_method;
 


### PR DESCRIPTION
The URL_BASE constant was being overridden and so it was connecting via http (rather than https in the super class since c299dfa1b095e268dce8ed1f6ac93ccbf403a832). My app was refusing to authenticate against the API and making this change fixed it for me... 
