### PR TITLE
Added 'array' parameter type to 'setTrack' to throw more meaningful error when only string is used

### DIFF
--- a/lib/Phirehose.php
+++ b/lib/Phirehose.php
@@ -205,7 +205,7 @@ abstract class Phirehose
    *
    * @param array $trackWords
    */
-  public function setTrack($trackWords)
+  public function setTrack(array $trackWords)
   {
     $trackWords = ($trackWords === NULL) ? array() : $trackWords;
     sort($trackWords); // Non-optimal, but necessary


### PR DESCRIPTION
Added 'array' parameter type to 'setTrack' to throw more meaningful error when only string is used
