### PR TITLE
call pcntl_signal_dispatch in consume to make the script able to handle posix signals

### DIFF
--- a/lib/Phirehose.php
+++ b/lib/Phirehose.php
@@ -451,6 +451,10 @@ abstract class Phirehose
       $this->lastErrorNo = is_resource($this->conn) ? @socket_last_error($this->conn) : NULL;
       $this->lastErrorMsg = ($this->lastErrorNo > 0) ? @socket_strerror($this->lastErrorNo) : 'Socket disconnected';
       $this->log('Phirehose connection error occured: ' . $this->lastErrorMsg,'error');
+
+      if (function_exists('pcntl_signal_dispatch')) {
+        pcntl_signal_dispatch();
+      }
       
       // Reconnect
     } while ($this->reconnect);


### PR DESCRIPTION
If running as a php daemon, sending a SIGTERM or any other signal which is not SIGKILL, execution stucks in consume method, because the while ($this->reconnect) loop.
A "Phirehose connection error occured: Socket disconnected" error raises, but the loop starts again.
Calling a pcntl_signal_dispatch allows the signal to be handled properly.
