### PR TITLE
move up call pcntl_signal_dispatch above error logging to prevent raising an error on term signal

### DIFF
--- a/lib/Phirehose.php
+++ b/lib/Phirehose.php
@@ -447,15 +447,15 @@ abstract class Phirehose
         
       } // End while-stream-activity
 
+      if (function_exists('pcntl_signal_dispatch')) {
+        pcntl_signal_dispatch();
+      }
+
       // Some sort of socket error has occured
       $this->lastErrorNo = is_resource($this->conn) ? @socket_last_error($this->conn) : NULL;
       $this->lastErrorMsg = ($this->lastErrorNo > 0) ? @socket_strerror($this->lastErrorNo) : 'Socket disconnected';
       $this->log('Phirehose connection error occured: ' . $this->lastErrorMsg,'error');
 
-      if (function_exists('pcntl_signal_dispatch')) {
-        pcntl_signal_dispatch();
-      }
-      
       // Reconnect
     } while ($this->reconnect);
 


### PR DESCRIPTION
I moved up signap dispatch above error logging, because when a SIGTERM signal sent by a kill command, the script reached that statement, and generated a 'Socket disconnected' error, though there was no actual error, the disconnection of socket was expected.
It can prevent sending unnecessary error mails or logging errors.
