### PR TITLE
Fixes for OauthPhirehose class to examples.

### DIFF
--- a/example/filter-reconfigure.php
+++ b/example/filter-reconfigure.php
@@ -1,16 +1,18 @@
 <?php
 require_once('../lib/Phirehose.php');
+require_once('../lib/OauthPhirehose.php');
+
 /**
- * Example of how to update filter predicates using Phirehose 
+ * Example of how to update filter predicates using Phirehose
  */
 class DynamicTrackConsumer extends OauthPhirehose
 {
-  
+
   /**
    * Subclass specific attribs
    */
   protected $myTrackWords = array('morning', 'goodnight', 'hello', 'the');
-  
+
   /**
    * Enqueue each status
    *
@@ -20,20 +22,20 @@ class DynamicTrackConsumer extends OauthPhirehose
   {
     // We won't actually do anything with statuses in this example, see updateFilterPredicates() for important stuff
   }
-  
+
   /**
    * In this example, we just set the track words to a random 2 words. In a real example, you'd want to check some sort
    * of shared medium (ie: memcache, DB, filesystem) to determine if the filter has changed and set appropriately. The
-   * speed of this method will affect how quickly you can update filters. 
+   * speed of this method will affect how quickly you can update filters.
    */
   public function checkFilterPredicates()
   {
     // This is all that's required, Phirehose will detect the change and reconnect as soon as possible
     $randWord1 = $this->myTrackWords[rand(0, 3)];
     $randWord2 = $this->myTrackWords[rand(0, 3)];
-    $this->setTrack(array($randWord1, $randWord2)); 
+    $this->setTrack(array($randWord1, $randWord2));
   }
-  
+
 }
 
 // The OAuth credentials you received when registering your app at Twitter

--- a/example/filter-track-geo.php
+++ b/example/filter-track-geo.php
@@ -1,7 +1,9 @@
 <?php
 require_once('../lib/Phirehose.php');
+require_once('../lib/OauthPhirehose.php');
+
 /**
- * Example of using Phirehose to display a live filtered stream using geo locations 
+ * Example of using Phirehose to display a live filtered stream using geo locations
  */
 class FilterTrackConsumer extends OauthPhirehose
 {
@@ -15,7 +17,7 @@ class FilterTrackConsumer extends OauthPhirehose
     /*
      * In this simple example, we will just display to STDOUT rather than enqueue.
      * NOTE: You should NOT be processing tweets at this point in a real application, instead they should be being
-     *       enqueued and processed asyncronously from the collection process. 
+     *       enqueued and processed asyncronously from the collection process.
      */
     $data = json_decode($status, true);
     if (is_array($data) && isset($data['user']['screen_name'])) {
@@ -37,6 +39,6 @@ define("OAUTH_SECRET", "");
 $sc = new FilterTrackConsumer(OAUTH_TOKEN, OAUTH_SECRET, Phirehose::METHOD_FILTER);
 $sc->setLocations(array(
        array(-122.75, 36.8, -121.75, 37.8), // San Francisco
-       array(-74, 40, -73, 41),             // New York 
+       array(-74, 40, -73, 41),             // New York
    ));
 $sc->consume();

--- a/example/filter-track.php
+++ b/example/filter-track.php
@@ -1,7 +1,9 @@
 <?php
 require_once('../lib/Phirehose.php');
+require_once('../lib/OauthPhirehose.php');
+
 /**
- * Example of using Phirehose to display a live filtered stream using track words 
+ * Example of using Phirehose to display a live filtered stream using track words
  */
 class FilterTrackConsumer extends OauthPhirehose
 {
@@ -15,7 +17,7 @@ class FilterTrackConsumer extends OauthPhirehose
     /*
      * In this simple example, we will just display to STDOUT rather than enqueue.
      * NOTE: You should NOT be processing tweets at this point in a real application, instead they should be being
-     *       enqueued and processed asyncronously from the collection process. 
+     *       enqueued and processed asyncronously from the collection process.
      */
     $data = json_decode($status, true);
     if (is_array($data) && isset($data['user']['screen_name'])) {

--- a/example/ghetto-queue-collect.php
+++ b/example/ghetto-queue-collect.php
@@ -1,24 +1,26 @@
 <?php
 require_once('../lib/Phirehose.php');
+require_once('../lib/OauthPhirehose.php');
+
 /**
- * Example of using Phirehose to collect tweets to a "ghetto queue" (ie: simple, filesystem based queue). 
+ * Example of using Phirehose to collect tweets to a "ghetto queue" (ie: simple, filesystem based queue).
  * This is not designed to be a production-ready/scalable collection system but is simple and does not rely on any
- * additional software or PHP modules. 
- * 
+ * additional software or PHP modules.
+ *
  * The idea with the ghetto queue is that a file is opened to collect tweets and rotate periodically to be processed by
- * a separate processing process. If you need "live" processing (ie: realtime auto-responses to tweets) you'd want to 
+ * a separate processing process. If you need "live" processing (ie: realtime auto-responses to tweets) you'd want to
  * keep this low - ie: 5-10 seconds. If you're doing analytics, you should rotate less often (perhaps every hour or so).
- * 
+ *
  */
-class GhettoQueueCollector extends extends OauthPhirehose
+class GhettoQueueCollector extends OauthPhirehose
 {
-  
+
   /**
    * Subclass specific constants
    */
   const QUEUE_FILE_PREFIX = 'phirehose-ghettoqueue';
   const QUEUE_FILE_ACTIVE = '.phirehose-ghettoqueue.current';
-  
+
   /**
    * Member attributes specific to this subclass
    */
@@ -27,10 +29,10 @@ class GhettoQueueCollector extends extends OauthPhirehose
   protected $streamFile;
   protected $statusStream;
   protected $lastRotated;
-  
+
   /**
    * Overidden constructor to take class-specific parameters
-   * 
+   *
    * @param string $username
    * @param string $password
    * @param string $queueDir
@@ -38,20 +40,20 @@ class GhettoQueueCollector extends extends OauthPhirehose
    */
   public function __construct($username, $password, $queueDir = '/tmp', $rotateInterval = 10)
   {
-    
+
     // Sanity check
     if ($rotateInterval < 5) {
       throw new Exception('Rotate interval set too low - Must be >= 5 seconds');
     }
-    
+
     // Set subclass parameters
     $this->queueDir = $queueDir;
     $this->rotateInterval = $rotateInterval;
-    
+
     // Call parent constructor
     return parent::__construct($username, $password, Phirehose::METHOD_FILTER);
   }
-  
+
   /**
    * Enqueue each status
    *
@@ -59,37 +61,37 @@ class GhettoQueueCollector extends extends OauthPhirehose
    */
   public function enqueueStatus($status)
   {
-    
+
     // Write the status to the stream (must be via getStream())
     fputs($this->getStream(), $status);
 
-    /* Are we due for a file rotate? Note this won't be called if there are no statuses coming through - 
+    /* Are we due for a file rotate? Note this won't be called if there are no statuses coming through -
      * This is (probably) a good thing as it means the collector won't needlessly rotate empty files. That said, if
-     * you have a very sparse/quiet stream that you need highly regular analytics on, this may not work for you. 
+     * you have a very sparse/quiet stream that you need highly regular analytics on, this may not work for you.
      */
     $now = time();
     if (($now - $this->lastRotated) > $this->rotateInterval) {
       // Mark last rotation time as now
       $this->lastRotated = $now;
-      
+
       // Rotate it
       $this->rotateStreamFile();
     }
-    
+
   }
-  
+
   /**
    * Returns a stream resource for the current file being written/enqueued to
-   * 
+   *
    * @return resource
    */
-  private function getStream() 
+  private function getStream()
   {
     // If we have a valid stream, return it
     if (is_resource($this->statusStream)) {
       return $this->statusStream;
     }
-    
+
     // If it's not a valid resource, we need to create one
     if (!is_dir($this->queueDir) || !is_writable($this->queueDir)) {
       throw new Exception('Unable to write to queueDir: ' . $this->queueDir);
@@ -99,22 +101,22 @@ class GhettoQueueCollector extends extends OauthPhirehose
     $this->streamFile = $this->queueDir . '/' . self::QUEUE_FILE_ACTIVE;
     $this->log('Opening new active status stream: ' . $this->streamFile);
     $this->statusStream = fopen($this->streamFile, 'a'); // Append if present (crash recovery)
-    
+
     // Ok?
     if (!is_resource($this->statusStream)) {
       throw new Exception('Unable to open stream file for writing: ' . $this->streamFile);
     }
-    
+
     // If we don't have a last rotated time, it's effectively now
     if ($this->lastRotated == NULL) {
       $this->lastRotated = time();
     }
-    
+
     // Looking good, return the resource
     return $this->statusStream;
-    
+
   }
-  
+
   /**
    * Rotates the stream file if due
    */
@@ -122,22 +124,22 @@ class GhettoQueueCollector extends extends OauthPhirehose
   {
     // Close the stream
     fclose($this->statusStream);
-    
+
     // Create queue file with timestamp so they're both unique and naturally ordered
     $queueFile = $this->queueDir . '/' . self::QUEUE_FILE_PREFIX . '.' . date('Ymd-His') . '.queue';
-    
+
     // Do the rotate
     rename($this->streamFile, $queueFile);
-    
+
     // Did it work?
     if (!file_exists($queueFile)) {
       throw new Exception('Failed to rotate queue file to: ' . $queueFile);
     }
-    
+
     // At this point, all looking good - the next call to getStream() will create a new active file
     $this->log('Successfully rotated active stream to queue file: ' . $queueFile);
   }
-  
+
 } // End of class
 
 // The OAuth credentials you received when registering your app at Twitter

--- a/example/sample.php
+++ b/example/sample.php
@@ -1,7 +1,9 @@
 <?php
 require_once('../lib/Phirehose.php');
+require_once('../lib/OauthPhirehose.php');
+
 /**
- * Example of using Phirehose to display the 'sample' twitter stream. 
+ * Example of using Phirehose to display the 'sample' twitter stream.
  */
 class SampleConsumer extends OauthPhirehose
 {
@@ -15,7 +17,7 @@ class SampleConsumer extends OauthPhirehose
     /*
      * In this simple example, we will just display to STDOUT rather than enqueue.
      * NOTE: You should NOT be processing tweets at this point in a real application, instead they should be being
-     *       enqueued and processed asyncronously from the collection process. 
+     *       enqueued and processed asyncronously from the collection process.
      */
     $data = json_decode($status, true);
     if (is_array($data) && isset($data['user']['screen_name'])) {


### PR DESCRIPTION
- Latest additions of Oauth to examples are not working as `OauthPhirehose.php` was not included.
- Fixed `ghetto-queue-collect.php` double "extends" in code.

Fixes are for pull request here: 9e1bbc3

P.S. there are also some removal of whitespace in this commit.
