### PR TITLE
Add settable ports for socket connect

### DIFF
--- a/lib/Phirehose.php
+++ b/lib/Phirehose.php
@@ -630,7 +630,7 @@ abstract class Phirehose
        */
       $errNo = $errStr = NULL;
       $scheme = ($urlParts['scheme'] == 'https') ? 'ssl://' : 'tcp://';
-      $port = ($urlParts['scheme'] == 'https') ? 443 : 80;
+      $port = ($urlParts['scheme'] == 'https') ? $this->secureHostPort : $this->hostPort;
       
       /**
        * We must perform manual host resolution here as Twitter's IP regularly rotates (ie: DNS TTL of 60 seconds) and


### PR DESCRIPTION
In our test environment we are connecting through a proxy which isn't on port 80 or 443 so we require an interface to set the port number. This may or may not be worth merging in.
