### PR TITLE
Allow User Stream to use track parameters

### DIFF
--- a/lib/Phirehose.php
+++ b/lib/Phirehose.php
@@ -606,7 +606,7 @@ abstract class Phirehose
       }
       
       // Filter takes additional parameters
-      if ($this->method == self::METHOD_FILTER && count($this->trackWords) > 0) {
+      if (($this->method == self::METHOD_FILTER || $this->method == self::METHOD_USER) && count($this->trackWords) > 0) {
         $requestParams['track'] = implode(',', $this->trackWords);
       }
       if ( ($this->method == self::METHOD_FILTER || $this->method == self::METHOD_SITE)


### PR DESCRIPTION
Unless I've missed something, the Phirehose library currently won't accept any track parameters even though it looks like they should be allowed according to: https://dev.twitter.com/docs/api/1.1/get/user

This PR adds the ability to add track parameters using the usual setTrack function.
