### PR TITLE
Fix for "Transfer-Encoding" header occasionally returned in lower-case

### DIFF
--- a/lib/Phirehose.php
+++ b/lib/Phirehose.php
@@ -707,7 +707,7 @@ abstract class Phirehose
       // Consume each header response line until we get to body
       while ($hLine = trim(fgets($this->conn, 4096))) {
         $respHeaders .= $hLine."\n";
-        if($hLine=='Transfer-Encoding: chunked')$isChunking=true;
+        if(strtolower($hLine) == 'transfer-encoding: chunked') $isChunking = true;
       }
       
       // If we got a non-200 response, we need to backoff and retry


### PR DESCRIPTION
Relatively rarely, connecting to the Streaming API at https://stream.twitter.com/1.1/statuses/filter returns the "Transfer-Encoding" header in lower-case: "transfer-encoding: chunked". This currently triggers the Exception "Twitter did not send a chunking header. Is this really HTTP/1.1? (...)" (line 745).

I've opened a discussion on the Twitter dev site for this bug (currently awaiting moderation): https://dev.twitter.com/discussions/27837

Whether they can resolve it or not, it doesn't hurt to tolerate the lower-case version.
