### PR TITLE
Endpoint of UserStream API has been changed. Ref: https://dev.twitter…

### DIFF
--- a/lib/Phirehose.php
+++ b/lib/Phirehose.php
@@ -184,7 +184,7 @@ abstract class Phirehose
     $this->format = $format;
     $this->lang = $lang;
    switch($method){
-        case self::METHOD_USER:$this->URL_BASE = 'https://userstream.twitter.com/2/';break;
+        case self::METHOD_USER:$this->URL_BASE = 'https://userstream.twitter.com/1.1/';break;
         case self::METHOD_SITE:$this->URL_BASE = 'https://sitestream.twitter.com/1.1/';break;
         default:break;  //Stick to the default
         }


### PR DESCRIPTION
Endpoint of UserStream API has been changed. Ref: https://dev.twitter.com/streaming/reference/get/user. Old endpoint (https://userstream.twitter.com/2/) is not working since 2016-05-05 00:00.