### PR TITLE
Replace count() > 0 with !empty()  (fix PHP 7.2 warnings)

### DIFF
--- a/lib/Phirehose.php
+++ b/lib/Phirehose.php
@@ -606,14 +606,14 @@ abstract class Phirehose
       }
       
       // Filter takes additional parameters
-      if (($this->method == self::METHOD_FILTER || $this->method == self::METHOD_USER) && count($this->trackWords) > 0) {
+      if (($this->method == self::METHOD_FILTER || $this->method == self::METHOD_USER) && !empty($this->trackWords)) {
         $requestParams['track'] = implode(',', $this->trackWords);
       }
       if ( ($this->method == self::METHOD_FILTER || $this->method == self::METHOD_SITE)
-            && count($this->followIds) > 0) {
+            && !empty($this->followIds)) {
         $requestParams['follow'] = implode(',', $this->followIds);
       }
-      if ($this->method == self::METHOD_FILTER && count($this->locationBoxes) > 0) {
+      if ($this->method == self::METHOD_FILTER && !empty($this->locationBoxes)) {
         $requestParams['locations'] = implode(',', $this->locationBoxes);
       }
       if ($this->count <> 0) {


### PR DESCRIPTION
PHP 7.2 now emits a warning when calling `count` with a non-countable parameter (see https://wiki.php.net/rfc/counting_non_countables) which was happening in a couple of places with variables that happened to be null.