### PR TITLE
Fix interaction with the Sockets API under PHP 8.x

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@
 *.un~
 .cache
 .cache/*
+composer.lock
+vendor/

--- a/lib/Phirehose.php
+++ b/lib/Phirehose.php
@@ -518,8 +518,8 @@ abstract class Phirehose
         pcntl_signal_dispatch();
       }
 
-      // Some sort of socket error has occured
-      $this->lastErrorNo = is_resource($this->conn) ? @socket_last_error($this->conn) : NULL;
+      // Some sort of socket error has occurred
+      $this->lastErrorNo = is_resource($this->conn) ? @socket_last_error() : NULL;
       $this->lastErrorMsg = ($this->lastErrorNo > 0) ? @socket_strerror($this->lastErrorNo) : 'Socket disconnected';
       $this->log('Phirehose connection error occured: ' . $this->lastErrorMsg,'error');
 


### PR DESCRIPTION
This fix addresses the following [breaking change](https://www.php.net/manual/en/migration80.incompatible.php#migration80.incompatible.resource2object) introduced in PHP 8.0:

> socket_create(), socket_create_listen(), socket_accept(), socket_import_stream(), socket_addrinfo_connect(), socket_addrinfo_bind(), and socket_wsaprotocol_info_import() will now return a Socket object rather than a resource. socket_addrinfo_lookup() will now return an array of AddressInfo objects rather than resources.

I originally thought about using the [socket_import_stream](https://www.php.net/manual/en/function.socket-import-stream.php) function to convert the stream resource into a socket resource, but unfortunately, the function doesn't work in combination with SSL:

> **PHP Warning:** socket_import_stream(): Cannot represent a stream of type tcp_socket/ssl as a Socket Descriptor

---

With this simple change, the last socket-related error that occurred will be retrieved from PHP's own global internal store, as seen [here](https://github.com/php/php-src/blob/php-8.0.5/ext/sockets/sockets.c#L2080). This function behavior dates all the way back to PHP 5.x, so the change is pretty safe to apply unconditionally.

The rest of the codebase works fine under PHP 8.0.