### PR TITLE
PHP 8 issue

### DIFF
--- a/lib/OauthPhirehose.php
+++ b/lib/OauthPhirehose.php
@@ -30,7 +30,7 @@ abstract class OauthPhirehose extends Phirehose
 	protected function prepareParameters($method = null, $url = null,
 		array $params= [])
 	{
-		if (empty($method) || empty($url) )
+		if (empty($method) || empty($url))
 			return false;
 
 		$oauth['oauth_consumer_key'] = $this->consumerKey?$this->consumerKey:TWITTER_CONSUMER_KEY;

--- a/lib/OauthPhirehose.php
+++ b/lib/OauthPhirehose.php
@@ -30,7 +30,7 @@ abstract class OauthPhirehose extends Phirehose
 	protected function prepareParameters($method = null, $url = null,
 		array $params= [])
 	{
-		if (empty($method) || empty($url) || empty ($params) )
+		if (empty($method) || empty($url) )
 			return false;
 
 		$oauth['oauth_consumer_key'] = $this->consumerKey?$this->consumerKey:TWITTER_CONSUMER_KEY;

--- a/lib/OauthPhirehose.php
+++ b/lib/OauthPhirehose.php
@@ -28,9 +28,9 @@ abstract class OauthPhirehose extends Phirehose
     /**
     */
 	protected function prepareParameters($method = null, $url = null,
-		array $params)
+		array $params= [])
 	{
-		if (empty($method) || empty($url))
+		if (empty($method) || empty($url) || empty ($params) )
 			return false;
 
 		$oauth['oauth_consumer_key'] = $this->consumerKey?$this->consumerKey:TWITTER_CONSUMER_KEY;


### PR DESCRIPTION
Fix PHP 8 issue for #127 - added a = [] to give the third parameter a default of an empty array. Had it running on my system this afternoon and it appears to be working. I thought I needed to reject if it was empty but that caused a problem so I removed that change and left it with just the empty array assignment